### PR TITLE
Make Callback->get() match parent method prototype

### DIFF
--- a/Pages/Callback.php
+++ b/Pages/Callback.php
@@ -12,7 +12,7 @@ namespace IdnoPlugins\tumblr\Pages {
   class Callback extends \Idno\Common\Page
   {
 
-    function get()
+    function get($params = array())
     {
       $this->gatekeeper(); // Logged-in users only
       if ($token = $this->getInput('oauth_token')) {


### PR DESCRIPTION
Previously Callback's get() override did not match the parent's method prototype, this caused notice errors to appear.

Solution: modify the prototype to match.